### PR TITLE
Fix issue #11 (Unexpected EOF when reading chunked response body)

### DIFF
--- a/mega_test.go
+++ b/mega_test.go
@@ -325,13 +325,13 @@ func TestExportLink(t *testing.T) {
 	}
 
 	// Don't include decryption key
-	_, err = session.Link(node, false);
+	_, err = session.Link(node, false)
 	if err != nil {
 		t.Error("Failed to export link (key not included)")
 	}
 
 	// Do include decryption key
-	_, err = session.Link(node, true);
+	_, err = session.Link(node, true)
 	if err != nil {
 		t.Error("Failed to export link (key included)")
 	}


### PR DESCRIPTION
Details:
- Simply try to read the response body as bytes[] and retry again if ioutil.ReadAll() returns an error (while respecting `m.retries`)
- Also, sleep for 5 seconds before retrying, to allow server to recover
