### PR TITLE
Update utils.go

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"regexp"
 )
 
 func newHttpClient(timeout time.Duration) *http.Client {
@@ -282,9 +283,10 @@ func decryptAttr(key []byte, data []byte) (attr FileAttr, err error) {
 	mode := cipher.NewCBCDecrypter(block, iv)
 	buf := make([]byte, len(data))
 	mode.CryptBlocks(buf, base64urldecode([]byte(data)))
-
+        r, _ := regexp.Compile(`{".*"}`)	  
 	if string(buf[:4]) == "MEGA" {
 		str := strings.TrimRight(string(buf[4:]), "\x00")
+		str = r.FindString(str)		
 		err = json.Unmarshal([]byte(str), &attr)
 	}
 	return


### PR DESCRIPTION
Fix the BAD_ATTRIBUTE error which occurs when the decoded `{"n":"name"}` string includes extra characters which are not NUL
Tested on WinXPsp3, go 1.4
