### PR TITLE
Update README with new go doc website

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is an API client library for MEGA storage service. Currently, the library s
 
 ### API methods
 
-Please find full doc at [http://godoc.org/github.com/t3rm1n4l/go-mega](http://godoc.org/github.com/t3rm1n4l/go-mega)
+Please find full doc at [https://pkg.go.dev/github.com/t3rm1n4l/go-mega](https://pkg.go.dev/github.com/t3rm1n4l/go-mega)
 
 ### Testing
 


### PR DESCRIPTION
The old godoc website will soon redirect to the new pkg.go.dev website which provides more functionality. See https://blog.golang.org/pkg.go.dev-2020 for more information.