### PR TITLE
Add HTTPS only setting

### DIFF
--- a/mega.go
+++ b/mega.go
@@ -97,7 +97,7 @@ func (c *config) SetUploadWorkers(w int) error {
 	return EWORKER_LIMIT_EXCEEDED
 }
 
-// Set number of retries for api calls
+// Set use https for transfers
 func (c *config) SetHTTPS(e bool) {
 	c.https = e
 }

--- a/mega.go
+++ b/mega.go
@@ -97,6 +97,11 @@ func (c *config) SetUploadWorkers(w int) error {
 	return EWORKER_LIMIT_EXCEEDED
 }
 
+// Set number of retries for api calls
+func (c *config) SetHTTPS(e bool) {
+	c.https = e
+}
+
 type Mega struct {
 	config
 	// Version of the account

--- a/mega.go
+++ b/mega.go
@@ -34,6 +34,7 @@ const (
 	UPLOAD_WORKERS       = 1
 	MAX_UPLOAD_WORKERS   = 30
 	TIMEOUT              = time.Second * 10
+	HTTPSONLY            = false
 	minSleepTime         = 10 * time.Millisecond // for retries
 	maxSleepTime         = 5 * time.Second       // for retries
 )
@@ -44,6 +45,7 @@ type config struct {
 	dl_workers int
 	ul_workers int
 	timeout    time.Duration
+	https      bool
 }
 
 func newConfig() config {
@@ -53,6 +55,7 @@ func newConfig() config {
 		dl_workers: DOWNLOAD_WORKERS,
 		ul_workers: UPLOAD_WORKERS,
 		timeout:    TIMEOUT,
+		https:      HTTPSONLY,
 	}
 }
 
@@ -985,6 +988,9 @@ func (m *Mega) NewDownload(src *Node) (*Download, error) {
 	msg[0].Cmd = "g"
 	msg[0].G = 1
 	msg[0].N = src.hash
+	if m.config.https {
+		msg[0].SSL = 2
+	}
 	key := src.meta.key
 	m.FS.mutex.Unlock()
 

--- a/messages.go
+++ b/messages.go
@@ -117,6 +117,7 @@ type DownloadMsg struct {
 	G   int    `json:"g"`
 	P   string `json:"p,omitempty"`
 	N   string `json:"n,omitempty"`
+	SSL int    `json:"ssl,omitempty"`
 }
 
 type DownloadResp struct {


### PR DESCRIPTION
Adds the HTTPS only setting from MEGAsdk
Useful if your ISP throttles HTTP
Disabled by default, as its not the standard behaviour
Also solves https://github.com/t3rm1n4l/go-mega/issues/42