### PR TITLE
Add HTTPS only setting - retry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ build:
 	go build
 
 test:
-	go test -cpu 4 -v -race
+	go test -cpu 4 -v -race -args -https=0
+	go test -cpu 4 -v -race -args -https=1
 
 # Get the build dependencies
 build_dep:

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ build:
 	go build
 
 test:
-	go test -cpu 4 -v -race -args -https=0
-	go test -cpu 4 -v -race -args -https=1
+	go test -cpu 4 -v -race
 
 # Get the build dependencies
 build_dep:

--- a/mega.go
+++ b/mega.go
@@ -97,7 +97,7 @@ func (c *config) SetUploadWorkers(w int) error {
 	return EWORKER_LIMIT_EXCEEDED
 }
 
-// Set number of retries for api calls
+// Set use https for transfers
 func (c *config) SetHTTPS(e bool) {
 	c.https = e
 }

--- a/mega.go
+++ b/mega.go
@@ -97,6 +97,11 @@ func (c *config) SetUploadWorkers(w int) error {
 	return EWORKER_LIMIT_EXCEEDED
 }
 
+// Set number of retries for api calls
+func (c *config) SetHTTPS(e bool) {
+	c.https = e
+}
+
 type Mega struct {
 	config
 	// Version of the account

--- a/mega.go
+++ b/mega.go
@@ -34,6 +34,7 @@ const (
 	UPLOAD_WORKERS       = 1
 	MAX_UPLOAD_WORKERS   = 30
 	TIMEOUT              = time.Second * 10
+	HTTPSONLY            = false
 	minSleepTime         = 10 * time.Millisecond // for retries
 	maxSleepTime         = 5 * time.Second       // for retries
 )
@@ -44,6 +45,7 @@ type config struct {
 	dl_workers int
 	ul_workers int
 	timeout    time.Duration
+	https      bool
 }
 
 func newConfig() config {
@@ -53,6 +55,7 @@ func newConfig() config {
 		dl_workers: DOWNLOAD_WORKERS,
 		ul_workers: UPLOAD_WORKERS,
 		timeout:    TIMEOUT,
+		https:      HTTPSONLY,
 	}
 }
 
@@ -985,6 +988,9 @@ func (m *Mega) NewDownload(src *Node) (*Download, error) {
 	msg[0].Cmd = "g"
 	msg[0].G = 1
 	msg[0].N = src.hash
+	if m.config.https {
+		msg[0].SSL = 2
+	}
 	key := src.meta.key
 	m.FS.mutex.Unlock()
 

--- a/mega.go
+++ b/mega.go
@@ -1042,10 +1042,15 @@ func (m *Mega) NewDownload(src *Node) (*Download, error) {
 		return nil, err
 	}
 
+	downloadUrl := res[0].G
+	if m.config.https && strings.HasPrefix(downloadUrl, "http://") {
+		downloadUrl = "https://" + strings.TrimPrefix(downloadUrl, "http://")
+	}
+
 	d := &Download{
 		m:           m,
 		src:         src,
-		resourceUrl: res[0].G,
+		resourceUrl: downloadUrl,
 		aes_block:   aes_block,
 		iv:          iv,
 		mac_enc:     mac_enc,
@@ -1328,7 +1333,6 @@ func (m *Mega) NewUpload(parent *Node, name string, fileSize int64) (*Upload, er
 		return nil, err
 	}
 
-	uploadUrl := res[0].P
 	ukey := []uint32{0, 0, 0, 0, 0, 0}
 	for i, _ := range ukey {
 		ukey[i] = uint32(mrand.Int31())
@@ -1360,6 +1364,11 @@ func (m *Mega) NewUpload(parent *Node, name string, fileSize int64) (*Upload, er
 	// Do one empty request to get the completion handle
 	if len(chunks) == 0 {
 		chunks = append(chunks, chunkSize{position: 0, size: 0})
+	}
+
+	uploadUrl := res[0].P
+	if m.config.https && strings.HasPrefix(uploadUrl, "http://") {
+		uploadUrl = "https://" + strings.TrimPrefix(uploadUrl, "http://")
 	}
 
 	u := &Upload{

--- a/mega.go
+++ b/mega.go
@@ -1310,6 +1310,9 @@ func (m *Mega) NewUpload(parent *Node, name string, fileSize int64) (*Upload, er
 
 	msg[0].Cmd = "u"
 	msg[0].S = fileSize
+	if m.config.https {
+		msg[0].SSL = 2
+	}
 
 	request, err := json.Marshal(msg)
 	if err != nil {

--- a/mega_test.go
+++ b/mega_test.go
@@ -3,6 +3,7 @@ package mega
 import (
 	"crypto/md5"
 	"crypto/rand"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,6 +15,7 @@ import (
 
 var USER string = os.Getenv("MEGA_USER")
 var PASSWORD string = os.Getenv("MEGA_PASSWD")
+var HTTPS = flag.Bool("https", false, "Use HTTPS for transfers")
 
 // retry runs fn until it succeeds, using what to log and retrying on
 // EAGAIN.  It uses exponential backoff
@@ -45,6 +47,7 @@ func skipIfNoCredentials(t *testing.T) {
 func initSession(t *testing.T) *Mega {
 	skipIfNoCredentials(t)
 	m := New()
+	m.SetHTTPS(*HTTPS)
 	// m.SetDebugger(log.Printf)
 	retry(t, "Login", func() error {
 		return m.Login(USER, PASSWORD)

--- a/messages.go
+++ b/messages.go
@@ -117,6 +117,7 @@ type DownloadMsg struct {
 	G   int    `json:"g"`
 	P   string `json:"p,omitempty"`
 	N   string `json:"n,omitempty"`
+	SSL int    `json:"ssl,omitempty"`
 }
 
 type DownloadResp struct {

--- a/messages.go
+++ b/messages.go
@@ -130,6 +130,7 @@ type DownloadResp struct {
 type UploadMsg struct {
 	Cmd string `json:"a"`
 	S   int64  `json:"s"`
+	SSL int    `json:"ssl,omitempty"`
 }
 
 type UploadResp struct {


### PR DESCRIPTION
Adds the HTTPS only setting from MEGAsdk
Useful if your ISP throttles HTTP
Disabled by default, as its not the standard behaviour
Also solves https://github.com/t3rm1n4l/go-mega/issues/42

One thing is that MEGA wont always send a HTTPS link, which i fix by replacing the prefix.
It also makes me question if sending ssl=2 is necessary, but the original sdk does it, so imma keep it.