### PR TITLE
change on node hard delete

### DIFF
--- a/mega.go
+++ b/mega.go
@@ -1836,8 +1836,10 @@ func (m *Mega) Delete(node *Node, destroy bool) error {
 		return err
 	}
 
-	parent := m.FS.lookup[node.hash]
-	parent.removeChild(node)
+	nodeCache := m.FS.lookup[node.hash]
+	if nodeCache != nil && nodeCache.parent != nil {
+		nodeCache.parent.removeChild(node)
+	}
 	delete(m.FS.lookup, node.hash)
 
 	return nil


### PR DESCRIPTION
Hello there.
I've encountered a trouble while deleting a node with destroy set to be true. After hard deletion  the destroyed node can still be obtained by  **func (*MegaFS) PathLookup** while not existing in mega server. So I dig into it and found the node will only be removed from hash table but still exists in its parent's children slice. 
I made some change to handle this. But I am not sure whether the hard deletion you designed is meant to be used that way or something else. So plz check it when you are free. Anyway great appreciate for what you guys do for this fabulous tool.